### PR TITLE
Hotfix for jinjax components

### DIFF
--- a/oarepo_tools/babel/__init__.py
+++ b/oarepo_tools/babel/__init__.py
@@ -70,8 +70,15 @@ def prepare_babel_translation_dir(base_dir, i18n_configuration) -> Path:
 def extract_babel_messages(base_dir, i18n_configuration, translations_dir):
     babel_ini_file = base_dir / "babel.ini"
     # extract messages
+    jinjax_extra_source = str(
+        translations_dir.relative_to(base_dir) / "jinjax_messages.jinja"
+    )
 
-    sources = [x for x in i18n_configuration["babel_source_paths"] if x.strip()]
+    sources = [
+        x
+        for x in i18n_configuration["babel_source_paths"] + [jinjax_extra_source]
+        if x.strip()
+    ]
 
     translations_file = str(translations_dir / "messages.pot")
 
@@ -82,9 +89,10 @@ def extract_babel_messages(base_dir, i18n_configuration, translations_dir):
     find_jinjax_strings = """grep -E -hori '[^\{]\{\s_\(.*\)\s\}[^\}]'"""
     search_sources = f"{find_jinjax_strings} {' '.join(sources)}"
     reformat_for_babel = """awk '{print "{" substr($0, 2, length($0) - 2) "}"}'"""
-    output_path = translations_dir / "jinjax_messages.jinja"
 
-    extract_jinjax_strings = f"{search_sources} | {reformat_for_babel} > {output_path}"
+    extract_jinjax_strings = (
+        f"{search_sources} | {reformat_for_babel} > {jinjax_extra_source}"
+    )
     check_output(extract_jinjax_strings, shell=True)
 
     CommandLineInterface().run(

--- a/oarepo_tools/babel/__init__.py
+++ b/oarepo_tools/babel/__init__.py
@@ -1,7 +1,7 @@
 import shutil
 import sys
 from pathlib import Path
-
+from subprocess import check_output
 import click
 
 try:
@@ -92,6 +92,12 @@ def extract_babel_messages(base_dir, i18n_configuration, translations_dir):
             *sources,
         ]
     )
+
+    find_jinjax_strings = """grep -E -hori '[^\{]\{\s_\(.*\)\s\}[^\}]' oarepo_oaipmh_harvester | awk '{print "{" substr($0, 2, length($0) - 2) "}"}'"""
+    extract_jinjax_strings = (
+        f"{find_jinjax_strings} > {translations_dir / 'jinjax_messages.jinja'}"
+    )
+    check_output(extract_jinjax_strings, shell=True)
 
     return translations_dir
 

--- a/oarepo_tools/babel/__init__.py
+++ b/oarepo_tools/babel/__init__.py
@@ -79,6 +79,14 @@ def extract_babel_messages(base_dir, i18n_configuration, translations_dir):
         f"Extracting babel messages from {', '.join(sources)} -> {translations_file}"
     )
 
+    find_jinjax_strings = """grep -E -hori '[^\{]\{\s_\(.*\)\s\}[^\}]'"""
+    search_sources = f"{find_jinjax_strings} {' '.join(sources)}"
+    reformat_for_babel = """awk '{print "{" substr($0, 2, length($0) - 2) "}"}'"""
+    output_path = translations_dir / "jinjax_messages.jinja"
+
+    extract_jinjax_strings = f"{search_sources} | {reformat_for_babel} > {output_path}"
+    check_output(extract_jinjax_strings, shell=True)
+
     CommandLineInterface().run(
         [
             "pybabel",
@@ -92,12 +100,6 @@ def extract_babel_messages(base_dir, i18n_configuration, translations_dir):
             *sources,
         ]
     )
-
-    find_jinjax_strings = """grep -E -hori '[^\{]\{\s_\(.*\)\s\}[^\}]' oarepo_oaipmh_harvester | awk '{print "{" substr($0, 2, length($0) - 2) "}"}'"""
-    extract_jinjax_strings = (
-        f"{find_jinjax_strings} > {translations_dir / 'jinjax_messages.jinja'}"
-    )
-    check_output(extract_jinjax_strings, shell=True)
 
     return translations_dir
 

--- a/oarepo_tools/babel/babel.ini
+++ b/oarepo_tools/babel/babel.ini
@@ -18,3 +18,7 @@ encoding = utf-8
 
 [jinja2: **/templates/**.jinja]
 encoding = utf-8
+
+# Special case for jinjax translation strings
+[jinja2: **/translations/jinjax_messages.jinja]
+encoding = utf-8

--- a/oarepo_tools/i18next/__init__.py
+++ b/oarepo_tools/i18next/__init__.py
@@ -13,7 +13,7 @@ def extract_i18next_messages(base_dir: Path, i18n_configuration, translations_di
     npm_proj_env["LANGUAGES"] = ",".join(i18n_configuration["languages"] or ["en"])
 
     source_path_patterns = [
-        os.path.join(base_dir / source_path, "**/*.{js,jsx}")
+        os.path.join(base_dir / source_path, "**/*.{js,jsx,ts,tsx}")
         for source_path in i18n_configuration["i18next_source_paths"]
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-tools"
-version = "0.1.0"
+version = "0.1.1"
 description = "OARepo tools"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Babel is unable to extract strings passed as JinjaX component attributes, like this:

```jinja
<Field label={ _('created.label') }> {{ metadata.created }}</Field>
```

For these cases, this PR introduces a mechanism that collects & reformats such strings for babel extraction at:
```
translations/jinjax_messages.jinja
```
special babel source file